### PR TITLE
fixes to dot hit and clear visuals

### DIFF
--- a/Assets/Json/World 1/level_1.json
+++ b/Assets/Json/World 1/level_1.json
@@ -5,31 +5,31 @@
     "moves": 10,
     "dotsToSpawn": [
 
-        {
-            "type": "nesting"
-        },
-      
-       
+
         {
             "type": "blank"
+
+        },
+        {
+            "type": "normal",
+            "color": "blue"
+
+        },
+        {
+            "type": "normal",
+            "color": "purple"
 
         },
 
         {
             "type": "beetle",
             "color": "purple",
-            "directionX": -1,
-            "directionY": 0
-        },
-        {
-            "type": "beetle",
-            "color": "yellow",
             "directionX": 1,
             "directionY": 0
         }
 
 
-       
+
 
 
 
@@ -40,31 +40,10 @@
 
     ],
     "dotsOnBoard": [
-        {
-            "type": "beetle",
-            "color": "purple",
-            "row": 0,
-            "col": 0,
-            "directionX": 1,
-            "directionY": 0
-        },
-        {
-            "type": "normal",
-            "color": "red",
-            "row": 0,
-            "col": 1
-           
-        },
+        
 
 
-        {
-            "type": "beetle",
-            "color": "blue",
-            "row": 0,
-            "col": 2,
-            "directionX": -1,
-            "directionY": 0
-        }
+       
 
     ],
 

--- a/Assets/Scripts/Commands/ClearCommand.cs
+++ b/Assets/Scripts/Commands/ClearCommand.cs
@@ -41,7 +41,7 @@ public class ClearCommand : Command
 
 
 
-        yield return new WaitForSeconds(DotVisuals.defaultClearTime);
+        yield return new WaitForSeconds(DotVisuals.clearTime);
 
        
 

--- a/Assets/Scripts/Commands/CommandInvoker.cs
+++ b/Assets/Scripts/Commands/CommandInvoker.cs
@@ -63,13 +63,13 @@ public class CommandInvoker
     private IEnumerator CheckCommandsEnded()
     {
        
-        yield return new WaitForSeconds(0.5f); 
+        yield return new WaitForSeconds(0.8f); 
 
         if (commands.Count == 0  && !CommandsEnded)
         {
             
                 CommandsEnded = true;
-                Debug.Log("All commands have ended.");
+                Debug.Log(commandCount+ " All commands have ended.");
 
                 onCommandsEnded?.Invoke();
         }

--- a/Assets/Scripts/Commands/HitCommand.cs
+++ b/Assets/Scripts/Commands/HitCommand.cs
@@ -34,7 +34,7 @@ public class HitCommand : Command
                         DidExecute = true;
                         hits.Add(hittable);
                         CoroutineHandler.StartStaticCoroutine(hittable.Hit(hitType));
-                        if (hittable.HitCount >= hittable.HitsToClear)
+                        if (hittable.HitCount == hittable.HitsToClear)
                         {
                             toClear.Add(hittable);
                             CoroutineHandler.StartStaticCoroutine(hittable.Clear());
@@ -45,14 +45,8 @@ public class HitCommand : Command
 
             
         }
-        foreach (IHittable hittable in hits)
-        {
-            if (hittable is Dot dot)
-                yield return new WaitForSeconds(dot.visualController.Visuals.clearTime);
-            if (hittable is Tile tile)
-                yield return new WaitForSeconds(tile.visualController.Visuals.clearTime);
 
-        }
+        yield return new WaitForSeconds(DotVisuals.clearTime);
 
         yield return base.Execute(board);
 

--- a/Assets/Scripts/Controllers/DotController.cs
+++ b/Assets/Scripts/Controllers/DotController.cs
@@ -99,14 +99,10 @@ public class DotController
 
     }
 
-    public static void DestroyDot(Dot dot)
-    {
-        Object.Destroy(dot.gameObject);
-    }
 
     public static void DoBombDot(Dot dot)
     {
-        DestroyDot(dot);
+        dot.visualController.DisableSprites();
         board.CreateBomb(dot.Column, dot.Row);
     }
 

--- a/Assets/Scripts/Dots/Bomb.cs
+++ b/Assets/Scripts/Dots/Bomb.cs
@@ -61,13 +61,7 @@ public class Bomb : Dot, IExplodable
         Destroy(line.gameObject);
 
         yield return hittable.Hit(HitType.BombExplosion);
-        if (Hits.Contains(hittable))
-        {
-            if(hittable is Dot dot)
-            {
-                yield return dot.DoVisualHit(HitType.BombExplosion);
-            }
-        }
+        
         
 
     }

--- a/Assets/Scripts/Dots/Connectable Dots/BeetleDot.cs
+++ b/Assets/Scripts/Dots/Connectable Dots/BeetleDot.cs
@@ -42,6 +42,7 @@ public class BeetleDot : ColorableDot, IDirectional, IPreviewable
 
     public override IEnumerator Clear()
     {
+        
         NotifyDotCleared();
         DotController.DoBombDot(this);
         yield return null;

--- a/Assets/Scripts/Dots/Dot.cs
+++ b/Assets/Scripts/Dots/Dot.cs
@@ -63,6 +63,10 @@ public abstract class Dot : MonoBehaviour, IHittable
 
     public virtual IEnumerator DoVisualHit(HitType hitType)
     {
+        if(HitCount > HitsToClear)
+        {
+            yield break;
+        }
 
         if (hitType == HitType.BombExplosion)
         {

--- a/Assets/Scripts/Gameplay/Board.cs
+++ b/Assets/Scripts/Gameplay/Board.cs
@@ -13,7 +13,7 @@ public class Board : MonoBehaviour
     public Dot[,] Dots { get; private set; }
 
     public Tile[,] Tiles { get; private set; }
-
+    private List<IHittable> cleared;
     private TileData[] tilesOnBoard;
     public static event Action OnWin;
     private DotToSpawnData[] dotsToSpawn;
@@ -38,7 +38,7 @@ public class Board : MonoBehaviour
         Tiles = new Tile[level.width, level.height];
         lineManager = new LineManager(this);
         tilesOnBoard = level.tilesOnBoard;
-       
+        cleared = new();
         SetUpBoard();
 
 
@@ -69,7 +69,7 @@ public class Board : MonoBehaviour
     {
         Dot.onDotCleared += OnDotCleared;
         Tile.onTileCleared += OnTileCleared;
-
+        CommandInvoker.onCommandsEnded += OnCommandsEnded;
     }
      private void Update()
     {
@@ -79,7 +79,19 @@ public class Board : MonoBehaviour
     private void OnDotCleared(Dot dot)
     {
         Dots[dot.Column, dot.Row] = null;
-        DotController.DestroyDot(dot);
+        cleared.Add(dot); 
+    }
+
+    private void OnCommandsEnded()
+    {
+        foreach (IHittable hittable in cleared)
+        {
+            if (hittable is Dot dot)
+                Destroy(dot.gameObject);
+            if (hittable is Tile tile)
+                Destroy(tile.gameObject);
+        }
+        cleared.Clear();
     }
 
     private void OnTileCleared(Tile tile)

--- a/Assets/Scripts/Visuals/Dot Visuals/Beetle Dot Visuals/BeetleDotVisualController.cs
+++ b/Assets/Scripts/Visuals/Dot Visuals/Beetle Dot Visuals/BeetleDotVisualController.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using UnityEngine;
 using DG.Tweening;
 using static Type;
-using System.Net.NetworkInformation;
 
 public class BeetleDotVisualController : ColorDotVisualController
 {
     protected new BeetleDotVisuals Visuals;
     protected new BeetleDot Dot;
+    private List<GameObject> wings;
     public override void Init(Dot dot)
     {
         Visuals = dot.GetComponent<BeetleDotVisuals>();
@@ -18,13 +18,7 @@ public class BeetleDotVisualController : ColorDotVisualController
 
     protected override void SetUp()
     {
-        Rotate();
-        base.SetUp();
-    }
-
-    protected override void SetColor()
-    {
-        GameObject[] wings = new[] {
+        wings = new() {
             Visuals.leftWing1,
             Visuals.leftWing2,
             Visuals.leftWing3,
@@ -32,16 +26,49 @@ public class BeetleDotVisualController : ColorDotVisualController
             Visuals.rightWing2,
             Visuals.rightWing3
         };
+        Rotate();
+        base.SetUp();
+    }
+
+    protected override void SetColor()
+    {
+        
         foreach(GameObject wing in wings)
         {
-            SpriteRenderer spriteRenderer = wing.GetComponent<SpriteRenderer>();
-            
-            spriteRenderer.color = ColorSchemeManager.FromDotColor(Dot.Color);
-            
+            if(wing.TryGetComponent<SpriteRenderer>(out var spriteRenderer))
+            {
+                spriteRenderer.color = ColorSchemeManager.FromDotColor(Dot.Color);
+            }
         }
+           
         
     }
 
+    public override void DisableSprites()
+    {
+        foreach (GameObject wing in wings)
+        {
+            if (wing.TryGetComponent<SpriteRenderer>(out var spriteRenderer))
+            {
+                spriteRenderer.enabled = false;
+            }
+        }
+
+        base.DisableSprites();
+    }
+    public override void EnableSprites()
+    {
+        foreach (GameObject wing in wings)
+        {
+            if (wing.TryGetComponent<SpriteRenderer>(out var spriteRenderer))
+            {
+                spriteRenderer.enabled = true;
+            }
+        }
+
+
+        base.EnableSprites();
+    }
 
     private IEnumerator DoHitAnimation()
     {
@@ -68,44 +95,6 @@ public class BeetleDotVisualController : ColorDotVisualController
             yield return Dot.transform.DOMove(Dot.transform.position * 2, 1f);
         }
           
-
-    }
-
-    private GameObject GetCurrentRightWing()
-    {
-        if(Dot.HitCount == 0)
-        {
-            return Visuals.rightWing3;
-        }
-
-        if (Dot.HitCount == 1)
-        {
-            return Visuals.rightWing2;
-        }
-
-        else
-        {
-            return Visuals.rightWing1;
-        }
-        
-    }
-
-    private GameObject GetCurrentLeftWing()
-    {
-        if (Dot.HitCount == 0)
-        {
-            return Visuals.leftWing3;
-        }
-
-        if (Dot.HitCount == 1)
-        {
-            return Visuals.leftWing2;
-        }
-        else
-        {
-            return Visuals.leftWing1;
-        }
-
 
     }
 
@@ -177,7 +166,7 @@ public class BeetleDotVisualController : ColorDotVisualController
         Dot.transform.localRotation = Quaternion.Euler(rotation);
     }
 
-    public override IEnumerator Hit(Type.HitType hitType)
+    public override IEnumerator Hit(HitType hitType)
     {
         yield return DoHitAnimation();
         yield return base.Hit(hitType);
@@ -194,7 +183,8 @@ public class BeetleDotVisualController : ColorDotVisualController
         yield return new WaitForSeconds(0.7f);
         Object.Destroy(leftWing);
         Object.Destroy(rightWing);
-
+        wings.Remove(leftWing);
+        wings.Remove(rightWing);
 
 
 

--- a/Assets/Scripts/Visuals/Dot Visuals/Clock Dot Visuals/ClockDotVisualController.cs
+++ b/Assets/Scripts/Visuals/Dot Visuals/Clock Dot Visuals/ClockDotVisualController.cs
@@ -53,7 +53,7 @@ public class ClockDotVisualController : BlankDotVisualController
             }
         }
 
-        yield return new WaitForSeconds(Visuals.clearTime);
+        yield return new WaitForSeconds(DotVisuals.clearTime);
 
         SetColor();
 

--- a/Assets/Scripts/Visuals/Dot Visuals/DotVisualController.cs
+++ b/Assets/Scripts/Visuals/Dot Visuals/DotVisualController.cs
@@ -41,7 +41,7 @@ public class DotVisualController : IDotVisualController
     {   
         SpriteRenderer.sprite = Visuals.bombHitSprite;
 
-        yield return new WaitForSeconds(Visuals.clearTime);
+        yield return new WaitForSeconds(DotVisuals.clearTime);
 
         SpriteRenderer.sprite = sprite;
 
@@ -71,12 +71,36 @@ public class DotVisualController : IDotVisualController
 
     public virtual IEnumerator Clear()
     {
-        Dot.transform.DOScale(Vector2.zero, Visuals.clearTime);
-        yield return new WaitForSeconds(Visuals.clearTime);
+        Dot.transform.DOScale(Vector2.zero, DotVisuals.clearTime);
+        yield return new WaitForSeconds(DotVisuals.clearTime);
     }
 
     public virtual IEnumerator PreviewHit(HitType hitType)
     {
         yield return null;
+    }
+
+    public virtual void DisableSprites()
+    {
+        SpriteRenderer.enabled = false;
+        foreach(Transform child in Dot.transform)
+        {
+            if(child.TryGetComponent<SpriteRenderer>(out var spriteRenderer))
+            {
+                spriteRenderer.enabled = false;
+            }
+        }
+    }
+
+    public virtual void EnableSprites()
+    {
+        SpriteRenderer.enabled = true;
+        foreach (Transform child in Dot.transform)
+        {
+            if (child.TryGetComponent<SpriteRenderer>(out var spriteRenderer))
+            {
+                spriteRenderer.enabled = true;
+            }
+        }
     }
 }

--- a/Assets/Scripts/Visuals/Dot Visuals/DotVisuals.cs
+++ b/Assets/Scripts/Visuals/Dot Visuals/DotVisuals.cs
@@ -5,10 +5,9 @@ using UnityEngine;
 public class DotVisuals : MonoBehaviour
 {
     public SpriteRenderer outerDot;
-    public float clearTime = 0.4f;
     public static float outerDotScaleTime = 0.8f;
     public static float outerDotAlphaTime = 0.8f;
     public Sprite bombHitSprite;
-    public static float defaultClearTime = 0.4f;
+    public static float clearTime = 0.4f;
 
 }

--- a/Assets/Scripts/Visuals/Dot Visuals/IDotVisualController.cs
+++ b/Assets/Scripts/Visuals/Dot Visuals/IDotVisualController.cs
@@ -11,6 +11,9 @@ public interface IDotVisualController
     public void Init(Dot dot);
     public IEnumerator PreviewHit(HitType hitType);
     public void SetColor(Color color);
+    public void DisableSprites();
+    public void EnableSprites();
+
     public IEnumerator Clear();
     public IEnumerator Hit(HitType hitType);
     public IEnumerator BombHit();


### PR DESCRIPTION
- Beetle dot visuals causing null reference errors have been resolved.
- Dots are now destroyed after all commands have ended.
- And when bombs are created, dot sprites are disabled rather than destroyed